### PR TITLE
Fixed convertPlistToJson crashing when trying to parse data from stream

### DIFF
--- a/src/convert.js
+++ b/src/convert.js
@@ -44,6 +44,7 @@ var extend = function(options) {
   return opts;
 };
 
+
 var convertCsvToJson = function (data, options, done) {
   csv()
     .from(data, options.csv)
@@ -77,7 +78,7 @@ var convertYmlToJson = function(data, options, done) {
 };
 
 var convertPlistToJson = function(data, options, done) {
-  var results = JSON.stringify(plist.parseFileSync(data), null, options.indent);
+  var results = JSON.stringify(plist.parseStringSync(data), null, options.indent);
   done(null, results);
 };
 


### PR DESCRIPTION
This is due to the fact that it was using `plist.parseFileSync` to parse the data incoming from the stream, but that data is actually just text. So this was crashing

``` js
fs.createReadStream('test.plist', { encoding='utf-8' })
  .pipe(converter({
    from: 'plist',
    to: 'json'
  })
  .pipe(fs.createWriteStream('test.json', { encoding='utf-8' });
```

which is basically the example given in the README.

I changed it to use `plist.parseStringSync` instead, which works fine.

James
